### PR TITLE
Fix Gemfile syntax.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ gem 'haml'
 
 group :development do
   gem 'guard-rspec'
-  gem 'transifex-ruby', github: 'jgraichen/transifex-ruby', require: false
-  gem 'inifile', require: false
+  gem 'transifex-ruby', :github => 'jgraichen/transifex-ruby', :require => false
+  gem 'inifile', :require => false
 end
 
 group :test do


### PR DESCRIPTION
Using Ruby 2.1.2 and Passenger 4.0.49, when Redmine starts the following
error appears in the Console:

```
stderr: /Users/me/.gem/ruby/2.1.2/gems/bundler-1.7.1/lib/bundler/dsl.rb:35:in `eval_gemfile': Gemfile syntax error compile error (Bundler::GemfileError)
stderr: /Users/me/Web/ruby/redmine/plugins/redmine_dashboard/Gemfile:8: syntax error, unexpected ':', expecting kEND
stderr: ... gem 'transifex-ruby', github: 'jgraichen/transifex-ruby', r...
stderr:                               ^
stderr: /Users/me/Web/ruby/redmine/plugins/redmine_dashboard/Gemfile:8: syntax error, unexpected ',', expecting kEND
stderr: ...b: 'jgraichen/transifex-ruby', require: false
stderr:                               ^
stderr: /Users/me/Web/ruby/redmine/plugins/redmine_dashboard/Gemfile:9: syntax error, unexpected ':', expecting kEND
stderr:   gem 'inifile', require: false
stderr:                          ^
stderr:     from /Users/me/.gem/ruby/2.1.2/gems/bundler-1.7.1/lib/bundler/dsl.rb:10:in `evaluate'
stderr:     from /Users/me/.gem/ruby/2.1.2/gems/bundler-1.7.1/lib/bundler/definition.rb:25:in `build'
stderr:     from /Users/me/.gem/ruby/2.1.2/gems/bundler-1.7.1/lib/bundler.rb:154:in `definition'
stderr:     from /Users/me/.gem/ruby/2.1.2/gems/bundler-1.7.1/lib/bundler.rb:117:in `setup'
stderr:     from /Users/me/.gem/ruby/2.1.2/gems/bundler-1.7.1/lib/bundler/setup.rb:17
```

Fix the error by updating the syntax for specifying gem options.
