### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'haml'
 
 group :development do
   gem 'guard-rspec'
-  gem 'transifex-ruby', github: 'jgraichen/transifex-ruby', require: false
+  gem 'transifex-ruby-fork-jg', github: 'jgraichen/transifex-ruby', require: false
   gem 'inifile', require: false
 end
 


### PR DESCRIPTION
bundle install fails because the gem name for repo "jgraichen/transifex-ruby" should be transifex-ruby-fork-jg, not transifex-ruby
