### PR TITLE
Slim compatible usage with other Redmine plugins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,7 @@ source 'https://rubygems.org'
 send :ruby, RUBY_VERSION if ENV['CI']
 
 gem 'rake'
-gem 'slim', '~> 4.1'
-gem 'slim-rails', '~> 3.3'
+gem 'slim-rails'
 
 group :test do
   gem 'database_cleaner-active_record', '~> 2.0'


### PR DESCRIPTION
It would be great, if slim-rails did not specify a version. Other redmine plugins use it this way to get max compatibility. If a version is specified, all other plugins have to use exactly the same version - which is very unlikely to happen.

slim-rails is very stable and I don't think there is a big risk to use it without version. Of course, in an ideal world a version would be better - but in Redmine plugin ecosystem this comes with problems.