### PR TITLE
Call issue edit before save hook

### DIFF
--- a/app/controllers/rdb_taskboard_controller.rb
+++ b/app/controllers/rdb_taskboard_controller.rb
@@ -42,7 +42,10 @@ class RdbTaskboardController < RdbDashboardController
           issue: @issue.subject, source: @issue.status.name, target: @status.name
       end
     end
-
+    call_hook(
+      :controller_issues_edit_before_save,
+      {:params => {}, :issue => @issue,
+       :journal => @issue.current_journal})
     @issue.save
 
     render 'index'

--- a/app/controllers/rdb_taskboard_controller.rb
+++ b/app/controllers/rdb_taskboard_controller.rb
@@ -47,6 +47,10 @@ class RdbTaskboardController < RdbDashboardController
       {:params => {}, :issue => @issue,
        :journal => @issue.current_journal})
     @issue.save
+    call_hook(
+      :controller_issues_edit_after_save,
+      {:params => {}, :issue => @issue,
+       :journal => @issue.current_journal})
 
     render 'index'
   end


### PR DESCRIPTION
After moving a card, there is a function `update` in `RdbTaskboardController` controller that saves changes on issue by itself and ignores hooks like `controller_issues_edit_before_save` and `controller_issues_edit_after_save`.
Many of other plugins may be developed in way that do changes on issue by defining related hooks.