### PR TITLE
chore: Bundler 2.4.0 fails to resolve deps for Redmine

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: True
+          bundler: '2.3.14'
 
       - name: setup cache
         uses: actions/cache@v3


### PR DESCRIPTION
See https://github.com/rubygems/rubygems/issues/6188.