### PR TITLE
assests url wrong on development env

### DIFF
--- a/app/views/rdb_dashboard/index.html.slim
+++ b/app/views/rdb_dashboard/index.html.slim
@@ -1,5 +1,5 @@
 - content_for :header_tags do
-  - plugin = Rails.env.development? ? 'redmine_dashboard_linked' : 'redmine_dashboard'
+  - plugin = Rails.env.development? ? 'redmine_dashboard' : 'redmine_dashboard'
   = stylesheet_link_tag 'dashboard.css', plugin: plugin
   = stylesheet_link_tag 'dashboard.ui.css', plugin: plugin
   = stylesheet_link_tag 'dashboard.issues.css', plugin: plugin


### PR DESCRIPTION
when running under development env, it reports error in browser.


```
Started GET "/plugin_assets/redmine_dashboard_linked/javascripts/jquery.total-storage.js" for 127.0.0.1 at 2024-09-25 20:24:01 +0800
Started GET "/plugin_assets/redmine_dashboard_linked/javascripts/dashboard.js" for 127.0.0.1 at 2024-09-25 20:24:01 +0800

ActionController::RoutingError (No route matches [GET] "/plugin_assets/redmine_dashboard_linked/javascripts/jquery.total-storage.js"):

Started GET "/plugin_assets/redmine_dashboard_linked/javascripts/dashboard.taskboard.js" for 127.0.0.1 at 2024-09-25 20:24:01 +0800
Started GET "/plugin_assets/redmine_dashboard_linked/javascripts/dashboard.ui.js" for 127.0.0.1 at 2024-09-25 20:24:01 +0800

ActionController::RoutingError (No route matches [GET] "/plugin_assets/redmine_dashboard_linked/javascripts/dashboard.js"):

Started GET "/plugin_assets/redmine_dashboard_linked/javascripts/jquery.ui.js" for 127.0.0.1 at 2024-09-25 20:24:01 +0800

ActionController::RoutingError (No route matches [GET] "/plugin_assets/redmine_dashboard_linked/javascripts/dashboard.taskboard.js"):
```


## Environment:
  Redmine version                5.1.3.stable
  Ruby version                   3.2.2-p53 (2023-03-30) [arm64-darwin24]
  Rails version                  6.1.7.8
  Environment                    development
  Database adapter               SQLite
  Mailer queue                   ActiveJob::QueueAdapters::AsyncAdapter
  Mailer delivery                smtp
Redmine settings:
  Redmine theme                  Default
SCM:
  Git                            2.39.5
  Filesystem                     
Redmine plugins:
  redmine_agile                  1.6.9
  redmine_dashboard              2.15.0