### PR TITLE
feat: Support configurable priority colors

### DIFF
--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -1,11 +1,11 @@
 {
   "Exclude": [
-    "LICENSE",
+    ".husky/",
+    ".ruby-lsp/",
     "assets/javascripts/jquery.total-storage.js",
-    "^vendor/",
-    "^node_modules/",
-    "^.husky/_/",
-    "^.ruby-lsp/"
+    "LICENSE",
+    "node_modules/",
+    "vendor/redmine/"
   ],
   "Disable": {
     "IndentSize": true

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-bun lint-staged
+lint-staged

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This [Redmine](http://redmine.org) plugin adds an issue dashboard that supports 
 
 ## Features List
 
-- Drag-n-drop of issues
+- Drag-and-drop of issues
 - Configurable columns
 - Grouping & Filtering
 - Group folding
@@ -32,7 +32,8 @@ Please ask your questions, or tell us your stories or experience on [GitHub Disc
 1. Download the [latest release](https://github.com/jgraichen/redmine_dashboard/releases).
 2. Extract archive to `<redmine>/plugins`.
    Make **sure** the plugin directory is called `<redmine>/plugins/redmine_dashboard/` ([#11](https://github.com/jgraichen/redmine_dashboard/issues/11)).
-3. A database migration is not needed. Restart Redmine.
+3. Run database migrations with `bundle exec rake redmine:plugins:migrate RAILS_ENV=production`.
+4. Restart Redmine.
 
 ### Configure Redmine
 
@@ -46,11 +47,11 @@ Please ask your questions, or tell us your stories or experience on [GitHub Disc
 
 ## Contribute
 
-I appreciate any help and like Pull Requests. The `main` branch is the current stable branch for v2. The next version, Redmine Dashboard 3, a complete rewrite had been under development on the `develop` branch. Due to limited available time the project is in maintenance only mode but open to new contributors.
+I appreciate any help and like Pull Requests. The `main` branch is the current stable branch for v2. Due to limited available time the project is in maintenance-only mode but open to new contributions and bug fixes.
 
 I gladly accept new translations or language additions for any version of Redmine Dashboard. I would prefer new translations via [Transifex](https://www.transifex.com/projects/p/redmine-dashboard/), but you can also send a Pull Request. Feel free to request new languages or to join the team directly on Transifex.
 
 ## License
 
-Redmine dashboard is licensed under the Apache License, Version 2.0.
+Redmine Dashboard is licensed under the Apache License, Version 2.0.
 See LICENSE for more information.

--- a/app/views/enumerations/_form.html.erb
+++ b/app/views/enumerations/_form.html.erb
@@ -1,0 +1,32 @@
+<%= error_messages_for 'enumeration' %>
+
+<div class="box tabular">
+  <p><%= f.text_field :name %></p>
+  <p><%= f.check_box :active %></p>
+  <p><%= f.check_box :is_default %></p>
+
+  <% @enumeration.custom_field_values.each do |value| %>
+    <p><%= custom_field_tag_with_label :enumeration, value %></p>
+  <% end %>
+</div>
+
+<% if @enumeration.respond_to?(:dashboard_color_css_class) && @enumeration.respond_to?(:dashboard_color) %>
+  <fieldset class="box">
+    <legend><%= I18n.t('rdb.enumeration.dashboard_color') %></legend>
+
+    <span class="rdb-enumeration-color-palettes">
+      <% RedmineDashboard::Color::PALETTE.each do |_, colors| %>
+        <ol>
+          <% colors.each do |color| %>
+            <li>
+              <label class="rdb-enumeration-color-label rdb-color-<%= color %>">
+                <%= f.radio_button :dashboard_color, color %>
+                <span><%= color %></span>
+              </label>
+            </li>
+          <% end %>
+        </ol>
+      <% end %>
+    </span>
+  </fieldset>
+<% end %>

--- a/app/views/rdb_dashboard/_footer.html.erb
+++ b/app/views/rdb_dashboard/_footer.html.erb
@@ -9,16 +9,15 @@
       <p><%= t(:rdb_legend_priorities) %></p>
 
       <% IssuePriority.all.sort_by(&:position).each do |priority| %>
-        <span class="rdb-priority rdb-priority-<%= priority.position %>">
+        <%= tag.span(class: class_names("rdb-priority", priority.dashboard_color_css_class)) do %>
           <%= priority %>
-        </span>
+        <% end %>
       <% end %>
     </div>
 
     <div>
       <p><%= t(:rdb_legend_warnings) %></p>
-      <span class="rdb-overdue"><span>&nbsp;</span></span>
-      <%= t(:rdb_issue_overdue) %>
+      <span class="rdb-overdue"><%= t(:rdb_issue_overdue) %></span>
     </div>
   </div>
 

--- a/app/views/rdb_dashboard/issues/_card.html.erb
+++ b/app/views/rdb_dashboard/issues/_card.html.erb
@@ -1,5 +1,5 @@
 <div class="rdb-card">
-  <div class="rdb-priority rdb-priority-<%= issue.priority.position %>">
+  <%= tag.div(class: class_names("rdb-priority", issue.priority.dashboard_color_css_class)) do %>
     <header class="rdb-card-header">
       <div class="rdb-card-title">
         <%= render partial: 'rdb_dashboard/issues/issue_menu', locals: {issue: issue} %>
@@ -22,5 +22,5 @@
 
       <%= render partial: 'rdb_dashboard/issues/issue_properties', locals: {issue: issue} %>
     </div>
-  </div>
+  <% end %>
 </div>

--- a/app/views/rdb_dashboard/issues/_compact.html.erb
+++ b/app/views/rdb_dashboard/issues/_compact.html.erb
@@ -1,5 +1,5 @@
 <div class="rdb-compact">
-  <div class="rdb-priority rdb-priority-<%= issue.priority.position %>">
+  <%= tag.div(class: class_names("rdb-priority", issue.priority.dashboard_color_css_class)) do %>
     <div class="rdb-compact-progress">
       <div
         class="rdb-compact-progress-bar"
@@ -22,5 +22,5 @@
         <%= issue.subject %>
       </div>
     </div>
-  </div>
+  <% end %>
 </div>

--- a/app/views/rdb_dashboard/issues/_compact.html.slim
+++ b/app/views/rdb_dashboard/issues/_compact.html.slim
@@ -1,0 +1,15 @@
+/ ISSUE COMPACT
+.rdb-compact
+  .rdb-priority class=issue.priority.dashboard_color_css_class
+
+    .rdb-compact-progress
+      .rdb-compact-progress-bar style="width: #{issue.done_ratio}%"
+    header.rdb-compact-header
+      .rdb-compact-title
+        = render partial: 'rdb_dashboard/issues/issue_menu', locals: {issue: issue}
+      .rdb-compact-header-data
+        = render partial: 'rdb_dashboard/issues/issue_properties', locals: {issue: issue}
+
+    .rdb-compact-content
+      .rdb-compact-subject.rdb-property-subject = issue.subject
+/ ISSUE COMPACT END

--- a/app/views/rdb_dashboard/taskboard/_column_dialog.html.erb
+++ b/app/views/rdb_dashboard/taskboard/_column_dialog.html.erb
@@ -1,6 +1,6 @@
 <div>
   <div class="rdb-card rdb-card-dialog">
-    <div class="rdb-priority rdb-priority-<%= @issue.priority.position %>">
+    <%= tag.div(class: class_names("rdb-priority", @issue.priority.dashboard_color_css_class)) do %>
       <header class="rdb-card-header">
         <span class="rdb-card-title">
           <%= link_to "#{@board.abbreviation(@issue.project_id)}#{@issue.id}", @issue %>
@@ -31,6 +31,6 @@
           <% end %>
         </ul>
       </div>
-    </div>
+    <% end %>
   </div>
 </div>

--- a/assets/stylesheets/dashboard.css
+++ b/assets/stylesheets/dashboard.css
@@ -195,7 +195,7 @@ a#rdb-reset {
 }
 
 #rdb-legend div {
-  padding: 0 0 4px;
+  padding: 0 0 0.75em;
 }
 
 #rdb-legend p {
@@ -214,12 +214,11 @@ a#rdb-reset {
 }
 
 #rdb-legend .rdb-overdue {
-  padding: 0;
-}
-
-#rdb-legend .rdb-overdue span {
-  border: 1px solid red;
-  padding: 0;
+  padding: 1px 0.25em;
+  margin: 0 3px 0 0;
+  border: 1px solid var(--rdb-overdue-color);
+  border-radius: 3px;
+  outline: 1px dotted var(--rdb-overdue-color);
 }
 
 #rdb-footer {

--- a/assets/stylesheets/dashboard.issues.css
+++ b/assets/stylesheets/dashboard.issues.css
@@ -6,7 +6,7 @@
   margin: 3px;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 3px;
+  gap: 4px;
 }
 
 .rdb-issue-dragged {
@@ -20,27 +20,7 @@
 */
 
 .rdb-priority {
-  border-left: 5px solid black;
-}
-
-.rdb-priority-1 {
-  border-color: #aaa;
-}
-
-.rdb-priority-2 {
-  border-color: #6b6;
-}
-
-.rdb-priority-3 {
-  border-color: orange;
-}
-
-.rdb-priority-4 {
-  border-color: red;
-}
-
-.rdb-priority-5 {
-  border-color: black;
+  border-left: 6px solid var(--rdb-color);
 }
 
 /* ========================================================
@@ -48,18 +28,20 @@
 */
 
 .rdb-card {
-  border: 1px solid #ccc;
   background: #ffd;
-  border-radius: 2px;
+  border: 1px solid #d0d7de;
+  border-radius: 3px;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 5%);
   position: relative;
-}
 
-.rdb-overdue .rdb-card {
-  border-color: red;
-}
+  .rdb-overdue & {
+    border-color: var(--rdb-overdue-color);
+    outline: 1px dotted var(--rdb-overdue-color);
+  }
 
-.rdb-card-title {
-  float: left;
+  .rdb-priority {
+    border-radius: 2px;
+  }
 }
 
 .rdb-card-header-data {
@@ -176,7 +158,8 @@
 }
 
 .rdb-overdue .rdb-compact {
-  border-color: red;
+  border-color: var(--rdb-overdue-color);
+  outline: 1px dotted var(--rdb-overdue-color);
 }
 
 .rdb-compact-header {
@@ -230,6 +213,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
+  line-clamp: 1;
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
 }

--- a/assets/stylesheets/global.css
+++ b/assets/stylesheets/global.css
@@ -1,0 +1,512 @@
+/* stylelint-disable custom-property-empty-line-before */
+
+:root {
+  --rdb-color-gray-100: oklch(82% 0 249.8deg);
+  --rdb-color-gray-300: oklch(66% 0 249.8deg);
+  --rdb-color-gray-500: oklch(50% 0 249.8deg);
+  --rdb-color-gray-700: oklch(34% 0 249.8deg);
+  --rdb-color-gray-900: oklch(18% 0 249.8deg);
+
+  --rdb-contrast-color-gray-100: oklch(34% 0 249.8deg);
+  --rdb-contrast-color-gray-300: oklch(18% 0 249.8deg);
+  --rdb-contrast-color-gray-500: oklch(95% 0 249.8deg);
+  --rdb-contrast-color-gray-700: oklch(82% 0 249.8deg);
+  --rdb-contrast-color-gray-900: oklch(66% 0 249.8deg);
+
+  --rdb-color-red-100: oklch(86.3% 0.102 17deg);
+  --rdb-color-red-300: oklch(64.7% 0.176 17deg);
+  --rdb-color-red-500: oklch(51.3% 0.168 17deg);
+  --rdb-color-red-700: oklch(39.4% 0.133 17deg);
+  --rdb-color-red-900: oklch(29.5% 0.082 17deg);
+
+  --rdb-contrast-color-red-100: oklch(29.5% 0.082 17deg);
+  --rdb-contrast-color-red-300: oklch(19.5% 0.082 17deg);
+  --rdb-contrast-color-red-500: oklch(95.1% 0.102 17deg);
+  --rdb-contrast-color-red-700: oklch(88.5% 0.102 17deg);
+  --rdb-contrast-color-red-900: oklch(86.3% 0.102 17deg);
+
+  --rdb-color-orange-100: oklch(86.9% 0.108 55deg);
+  --rdb-color-orange-300: oklch(67% 0.185 55deg);
+  --rdb-color-orange-500: oklch(50% 0.169 55deg);
+  --rdb-color-orange-700: oklch(38.1% 0.127 55deg);
+  --rdb-color-orange-900: oklch(28.4% 0.074 55deg);
+
+  --rdb-contrast-color-orange-100: oklch(38.1% 0.127 55deg);
+  --rdb-contrast-color-orange-300: oklch(28.4% 0.074 55deg);
+  --rdb-contrast-color-orange-500: oklch(96.9% 0.108 55deg);
+  --rdb-contrast-color-orange-700: oklch(86.2% 0.108 55deg);
+  --rdb-contrast-color-orange-900: oklch(82.9% 0.108 55deg);
+
+  --rdb-color-amber-100: oklch(89.4% 0.11 75deg);
+  --rdb-color-amber-300: oklch(73.3% 0.194 75deg);
+  --rdb-color-amber-500: oklch(50.1% 0.166 75deg);
+  --rdb-color-amber-700: oklch(38.3% 0.123 75deg);
+  --rdb-color-amber-900: oklch(28.8% 0.072 75deg);
+
+  --rdb-contrast-color-amber-100: oklch(38.1% 0.119 75deg);
+  --rdb-contrast-color-amber-300: oklch(28.6% 0.07 75deg);
+  --rdb-contrast-color-amber-500: oklch(96.2% 0.108 75deg);
+  --rdb-contrast-color-amber-700: oklch(89.2% 0.108 75deg);
+  --rdb-contrast-color-amber-900: oklch(80.5% 0.11 75deg);
+
+  --rdb-color-yellow-100: oklch(89.2% 0.108 91deg);
+  --rdb-color-yellow-300: oklch(72.5% 0.187 91deg);
+  --rdb-color-yellow-500: oklch(49.8% 0.161 91deg);
+  --rdb-color-yellow-700: oklch(38.1% 0.119 91deg);
+  --rdb-color-yellow-900: oklch(28.6% 0.07 91deg);
+
+  --rdb-contrast-color-yellow-100: oklch(38.1% 0.119 91deg);
+  --rdb-contrast-color-yellow-300: oklch(28.6% 0.07 91deg);
+  --rdb-contrast-color-yellow-500: oklch(96.2% 0.108 91deg);
+  --rdb-contrast-color-yellow-700: oklch(89.2% 0.108 91deg);
+  --rdb-contrast-color-yellow-900: oklch(80.5% 0.112 91deg);
+
+  --rdb-color-lime-100: oklch(89.2% 0.108 120deg);
+  --rdb-color-lime-300: oklch(72.5% 0.187 120deg);
+  --rdb-color-lime-500: oklch(49.8% 0.161 120deg);
+  --rdb-color-lime-700: oklch(38.1% 0.119 120deg);
+  --rdb-color-lime-900: oklch(28.6% 0.07 120deg);
+
+  --rdb-contrast-color-lime-100: oklch(38.1% 0.119 120deg);
+  --rdb-contrast-color-lime-300: oklch(28.6% 0.07 120deg);
+  --rdb-contrast-color-lime-500: oklch(96.2% 0.108 120deg);
+  --rdb-contrast-color-lime-700: oklch(89.2% 0.108 120deg);
+  --rdb-contrast-color-lime-900: oklch(80.5% 0.112 120deg);
+
+  --rdb-color-green-100: oklch(84.3% 0.107 145deg);
+  --rdb-color-green-300: oklch(62.3% 0.178 145deg);
+  --rdb-color-green-500: oklch(48.4% 0.164 145deg);
+  --rdb-color-green-700: oklch(36.7% 0.125 145deg);
+  --rdb-color-green-900: oklch(27.2% 0.076 145deg);
+
+  --rdb-contrast-color-green-100: oklch(36.7% 0.125 145deg);
+  --rdb-contrast-color-green-300: oklch(20.2% 0.076 145deg);
+  --rdb-contrast-color-green-500: oklch(91.3% 0.107 145deg);
+  --rdb-contrast-color-green-700: oklch(84.3% 0.107 145deg);
+  --rdb-contrast-color-green-900: oklch(72.3% 0.108 145deg);
+
+  --rdb-color-indigo-100: oklch(85% 0.107 275deg);
+  --rdb-color-indigo-300: oklch(63.2% 0.185 275deg);
+  --rdb-color-indigo-500: oklch(54% 0.19 275deg);
+  --rdb-color-indigo-700: oklch(37.5% 0.128 275deg);
+  --rdb-color-indigo-900: oklch(27.8% 0.075 275deg);
+
+  --rdb-contrast-color-indigo-100: oklch(37.4% 0.131 275deg);
+  --rdb-contrast-color-indigo-300: oklch(20.7% 0.077 275deg);
+  --rdb-contrast-color-indigo-500: oklch(99.1% 0.006 224.252deg);
+  --rdb-contrast-color-indigo-700: oklch(84.9% 0.107 275deg);
+  --rdb-contrast-color-indigo-900: oklch(72.9% 0.137 275deg);
+
+  --rdb-color-blue-100: oklch(84.9% 0.107 252deg);
+  --rdb-color-blue-300: oklch(62.9% 0.187 252deg);
+  --rdb-color-blue-500: oklch(49.3% 0.172 252deg);
+  --rdb-color-blue-700: oklch(37.4% 0.131 252deg);
+  --rdb-color-blue-900: oklch(27.7% 0.077 252deg);
+
+  --rdb-contrast-color-blue-100: oklch(37.4% 0.131 252deg);
+  --rdb-contrast-color-blue-300: oklch(20.7% 0.077 252deg);
+  --rdb-contrast-color-blue-500: oklch(90.9% 0.107 252deg);
+  --rdb-contrast-color-blue-700: oklch(84.9% 0.107 252deg);
+  --rdb-contrast-color-blue-900: oklch(72.9% 0.137 252deg);
+
+  --rdb-color-purple-100: oklch(85.3% 0.107 295deg);
+  --rdb-color-purple-300: oklch(63.7% 0.185 295deg);
+  --rdb-color-purple-500: oklch(49.5% 0.172 295deg);
+  --rdb-color-purple-700: oklch(37.6% 0.129 295deg);
+  --rdb-color-purple-900: oklch(27.9% 0.075 295deg);
+
+  --rdb-contrast-color-purple-100: oklch(37.6% 0.129 295deg);
+  --rdb-contrast-color-purple-300: oklch(20.9% 0.075 295deg);
+  --rdb-contrast-color-purple-500: oklch(90.3% 0.107 295deg);
+  --rdb-contrast-color-purple-700: oklch(85.3% 0.107 295deg);
+  --rdb-contrast-color-purple-900: oklch(73.7% 0.125 295deg);
+
+  --rdb-color-pink-100: oklch(85.7% 0.107 343deg);
+  --rdb-color-pink-300: oklch(64.1% 0.185 343deg);
+  --rdb-color-pink-500: oklch(49.8% 0.169 343deg);
+  --rdb-color-pink-700: oklch(37.9% 0.127 343deg);
+  --rdb-color-pink-900: oklch(28.2% 0.074 343deg);
+
+  --rdb-contrast-color-pink-100: oklch(37.6% 0.074 343deg);
+  --rdb-contrast-color-pink-300: oklch(20.9% 0.074 343deg);
+  --rdb-contrast-color-pink-500: oklch(90.3% 0.107 343deg);
+  --rdb-contrast-color-pink-700: oklch(85.3% 0.107 343deg);
+  --rdb-contrast-color-pink-900: oklch(73.7% 0.107 343deg);
+
+  --rdb-color-cyan-100: oklch(84.3% 0.107 210deg);
+  --rdb-color-cyan-300: oklch(62.3% 0.178 210deg);
+  --rdb-color-cyan-500: oklch(48.4% 0.164 210deg);
+  --rdb-color-cyan-700: oklch(36.7% 0.125 210deg);
+  --rdb-color-cyan-900: oklch(27.2% 0.076 210deg);
+
+  --rdb-contrast-color-cyan-100: oklch(37.2% 0.076 210deg);
+  --rdb-contrast-color-cyan-300: oklch(20.2% 0.076 210deg);
+  --rdb-contrast-color-cyan-500: oklch(95.3% 0.107 210deg);
+  --rdb-contrast-color-cyan-700: oklch(85.3% 0.107 210deg);
+  --rdb-contrast-color-cyan-900: oklch(74.3% 0.107 210deg);
+
+  --rdb-color-mint-100: oklch(83.1% 0.115 165deg);
+  --rdb-color-mint-300: oklch(60.9% 0.192 165deg);
+  --rdb-color-mint-500: oklch(48% 0.183 165deg);
+  --rdb-color-mint-700: oklch(36.3% 0.138 165deg);
+  --rdb-color-mint-900: oklch(26.9% 0.083 165deg);
+
+  --rdb-contrast-color-mint-100: oklch(36.3% 0.138 165deg);
+  --rdb-contrast-color-mint-300: oklch(20.9% 0.083 165deg);
+  --rdb-contrast-color-mint-500: oklch(93.1% 0.115 165deg);
+  --rdb-contrast-color-mint-700: oklch(83.1% 0.115 165deg);
+  --rdb-contrast-color-mint-900: oklch(73.1% 0.115 165deg);
+
+  --rdb-overdue-color: red;
+}
+
+.rdb-color-gray-100 {
+  --rdb-color: var(--rdb-color-gray-100);
+  --rdb-contrast-color: var(--rdb-contrast-color-gray-100);
+}
+
+.rdb-color-gray-300 {
+  --rdb-color: var(--rdb-color-gray-300);
+  --rdb-contrast-color: var(--rdb-contrast-color-gray-300);
+}
+
+.rdb-color-gray-500 {
+  --rdb-color: var(--rdb-color-gray-500);
+  --rdb-contrast-color: var(--rdb-contrast-color-gray-500);
+}
+
+.rdb-color-gray-700 {
+  --rdb-color: var(--rdb-color-gray-700);
+  --rdb-contrast-color: var(--rdb-contrast-color-gray-700);
+}
+
+.rdb-color-gray-900 {
+  --rdb-color: var(--rdb-color-gray-900);
+  --rdb-contrast-color: var(--rdb-contrast-color-gray-900);
+}
+
+.rdb-color-red-100 {
+  --rdb-color: var(--rdb-color-red-100);
+  --rdb-contrast-color: var(--rdb-contrast-color-red-100);
+}
+
+.rdb-color-red-300 {
+  --rdb-color: var(--rdb-color-red-300);
+  --rdb-contrast-color: var(--rdb-contrast-color-red-300);
+}
+
+.rdb-color-red-500 {
+  --rdb-color: var(--rdb-color-red-500);
+  --rdb-contrast-color: var(--rdb-contrast-color-red-500);
+}
+
+.rdb-color-red-700 {
+  --rdb-color: var(--rdb-color-red-700);
+  --rdb-contrast-color: var(--rdb-contrast-color-red-700);
+}
+
+.rdb-color-red-900 {
+  --rdb-color: var(--rdb-color-red-900);
+  --rdb-contrast-color: var(--rdb-contrast-color-red-900);
+}
+
+.rdb-color-orange-100 {
+  --rdb-color: var(--rdb-color-orange-100);
+  --rdb-contrast-color: var(--rdb-contrast-color-orange-100);
+}
+
+.rdb-color-orange-300 {
+  --rdb-color: var(--rdb-color-orange-300);
+  --rdb-contrast-color: var(--rdb-contrast-color-orange-300);
+}
+
+.rdb-color-orange-500 {
+  --rdb-color: var(--rdb-color-orange-500);
+  --rdb-contrast-color: var(--rdb-contrast-color-orange-500);
+}
+
+.rdb-color-orange-700 {
+  --rdb-color: var(--rdb-color-orange-700);
+  --rdb-contrast-color: var(--rdb-contrast-color-orange-700);
+}
+
+.rdb-color-orange-900 {
+  --rdb-color: var(--rdb-color-orange-900);
+  --rdb-contrast-color: var(--rdb-contrast-color-orange-900);
+}
+
+.rdb-color-amber-100 {
+  --rdb-color: var(--rdb-color-amber-100);
+  --rdb-contrast-color: var(--rdb-contrast-color-amber-100);
+}
+
+.rdb-color-amber-300 {
+  --rdb-color: var(--rdb-color-amber-300);
+  --rdb-contrast-color: var(--rdb-contrast-color-amber-300);
+}
+
+.rdb-color-amber-500 {
+  --rdb-color: var(--rdb-color-amber-500);
+  --rdb-contrast-color: var(--rdb-contrast-color-amber-500);
+}
+
+.rdb-color-amber-700 {
+  --rdb-color: var(--rdb-color-amber-700);
+  --rdb-contrast-color: var(--rdb-contrast-color-amber-700);
+}
+
+.rdb-color-amber-900 {
+  --rdb-color: var(--rdb-color-amber-900);
+  --rdb-contrast-color: var(--rdb-contrast-color-amber-900);
+}
+
+.rdb-color-yellow-100 {
+  --rdb-color: var(--rdb-color-yellow-100);
+  --rdb-contrast-color: var(--rdb-contrast-color-yellow-100);
+}
+
+.rdb-color-yellow-300 {
+  --rdb-color: var(--rdb-color-yellow-300);
+  --rdb-contrast-color: var(--rdb-contrast-color-yellow-300);
+}
+
+.rdb-color-yellow-500 {
+  --rdb-color: var(--rdb-color-yellow-500);
+  --rdb-contrast-color: var(--rdb-contrast-color-yellow-500);
+}
+
+.rdb-color-yellow-700 {
+  --rdb-color: var(--rdb-color-yellow-700);
+  --rdb-contrast-color: var(--rdb-contrast-color-yellow-700);
+}
+
+.rdb-color-yellow-900 {
+  --rdb-color: var(--rdb-color-yellow-900);
+  --rdb-contrast-color: var(--rdb-contrast-color-yellow-900);
+}
+
+.rdb-color-lime-100 {
+  --rdb-color: var(--rdb-color-lime-100);
+  --rdb-contrast-color: var(--rdb-contrast-color-lime-100);
+}
+
+.rdb-color-lime-300 {
+  --rdb-color: var(--rdb-color-lime-300);
+  --rdb-contrast-color: var(--rdb-contrast-color-lime-300);
+}
+
+.rdb-color-lime-500 {
+  --rdb-color: var(--rdb-color-lime-500);
+  --rdb-contrast-color: var(--rdb-contrast-color-lime-500);
+}
+
+.rdb-color-lime-700 {
+  --rdb-color: var(--rdb-color-lime-700);
+  --rdb-contrast-color: var(--rdb-contrast-color-lime-700);
+}
+
+.rdb-color-lime-900 {
+  --rdb-color: var(--rdb-color-lime-900);
+  --rdb-contrast-color: var(--rdb-contrast-color-lime-900);
+}
+
+.rdb-color-green-100 {
+  --rdb-color: var(--rdb-color-green-100);
+  --rdb-contrast-color: var(--rdb-contrast-color-green-100);
+}
+
+.rdb-color-green-300 {
+  --rdb-color: var(--rdb-color-green-300);
+  --rdb-contrast-color: var(--rdb-contrast-color-green-300);
+}
+
+.rdb-color-green-500 {
+  --rdb-color: var(--rdb-color-green-500);
+  --rdb-contrast-color: var(--rdb-contrast-color-green-500);
+}
+
+.rdb-color-green-700 {
+  --rdb-color: var(--rdb-color-green-700);
+  --rdb-contrast-color: var(--rdb-contrast-color-green-700);
+}
+
+.rdb-color-green-900 {
+  --rdb-color: var(--rdb-color-green-900);
+  --rdb-contrast-color: var(--rdb-contrast-color-green-900);
+}
+
+.rdb-color-indigo-100 {
+  --rdb-color: var(--rdb-color-indigo-100);
+  --rdb-contrast-color: var(--rdb-contrast-color-indigo-100);
+}
+
+.rdb-color-indigo-300 {
+  --rdb-color: var(--rdb-color-indigo-300);
+  --rdb-contrast-color: var(--rdb-contrast-color-indigo-300);
+}
+
+.rdb-color-indigo-500 {
+  --rdb-color: var(--rdb-color-indigo-500);
+  --rdb-contrast-color: var(--rdb-contrast-color-indigo-500);
+}
+
+.rdb-color-indigo-700 {
+  --rdb-color: var(--rdb-color-indigo-700);
+  --rdb-contrast-color: var(--rdb-contrast-color-indigo-700);
+}
+
+.rdb-color-indigo-900 {
+  --rdb-color: var(--rdb-color-indigo-900);
+  --rdb-contrast-color: var(--rdb-contrast-color-indigo-900);
+}
+
+.rdb-color-blue-100 {
+  --rdb-color: var(--rdb-color-blue-100);
+  --rdb-contrast-color: var(--rdb-contrast-color-blue-100);
+}
+
+.rdb-color-blue-300 {
+  --rdb-color: var(--rdb-color-blue-300);
+  --rdb-contrast-color: var(--rdb-contrast-color-blue-300);
+}
+
+.rdb-color-blue-500 {
+  --rdb-color: var(--rdb-color-blue-500);
+  --rdb-contrast-color: var(--rdb-contrast-color-blue-500);
+}
+
+.rdb-color-blue-700 {
+  --rdb-color: var(--rdb-color-blue-700);
+  --rdb-contrast-color: var(--rdb-contrast-color-blue-700);
+}
+
+.rdb-color-blue-900 {
+  --rdb-color: var(--rdb-color-blue-900);
+  --rdb-contrast-color: var(--rdb-contrast-color-blue-900);
+}
+
+.rdb-color-purple-100 {
+  --rdb-color: var(--rdb-color-purple-100);
+  --rdb-contrast-color: var(--rdb-contrast-color-purple-100);
+}
+
+.rdb-color-purple-300 {
+  --rdb-color: var(--rdb-color-purple-300);
+  --rdb-contrast-color: var(--rdb-contrast-color-purple-300);
+}
+
+.rdb-color-purple-500 {
+  --rdb-color: var(--rdb-color-purple-500);
+  --rdb-contrast-color: var(--rdb-contrast-color-purple-500);
+}
+
+.rdb-color-purple-700 {
+  --rdb-color: var(--rdb-color-purple-700);
+  --rdb-contrast-color: var(--rdb-contrast-color-purple-700);
+}
+
+.rdb-color-purple-900 {
+  --rdb-color: var(--rdb-color-purple-900);
+  --rdb-contrast-color: var(--rdb-contrast-color-purple-900);
+}
+
+.rdb-color-pink-100 {
+  --rdb-color: var(--rdb-color-pink-100);
+  --rdb-contrast-color: var(--rdb-contrast-color-pink-100);
+}
+
+.rdb-color-pink-300 {
+  --rdb-color: var(--rdb-color-pink-300);
+  --rdb-contrast-color: var(--rdb-contrast-color-pink-300);
+}
+
+.rdb-color-pink-500 {
+  --rdb-color: var(--rdb-color-pink-500);
+  --rdb-contrast-color: var(--rdb-contrast-color-pink-500);
+}
+
+.rdb-color-pink-700 {
+  --rdb-color: var(--rdb-color-pink-700);
+  --rdb-contrast-color: var(--rdb-contrast-color-pink-700);
+}
+
+.rdb-color-pink-900 {
+  --rdb-color: var(--rdb-color-pink-900);
+  --rdb-contrast-color: var(--rdb-contrast-color-pink-900);
+}
+
+.rdb-color-cyan-100 {
+  --rdb-color: var(--rdb-color-cyan-100);
+  --rdb-contrast-color: var(--rdb-contrast-color-cyan-100);
+}
+
+.rdb-color-cyan-300 {
+  --rdb-color: var(--rdb-color-cyan-300);
+  --rdb-contrast-color: var(--rdb-contrast-color-cyan-300);
+}
+
+.rdb-color-cyan-500 {
+  --rdb-color: var(--rdb-color-cyan-500);
+  --rdb-contrast-color: var(--rdb-contrast-color-cyan-500);
+}
+
+.rdb-color-cyan-700 {
+  --rdb-color: var(--rdb-color-cyan-700);
+  --rdb-contrast-color: var(--rdb-contrast-color-cyan-700);
+}
+
+.rdb-color-cyan-900 {
+  --rdb-color: var(--rdb-color-cyan-900);
+  --rdb-contrast-color: var(--rdb-contrast-color-cyan-900);
+}
+
+.rdb-color-mint-100 {
+  --rdb-color: var(--rdb-color-mint-100);
+  --rdb-contrast-color: var(--rdb-contrast-color-mint-100);
+}
+
+.rdb-color-mint-300 {
+  --rdb-color: var(--rdb-color-mint-300);
+  --rdb-contrast-color: var(--rdb-contrast-color-mint-300);
+}
+
+.rdb-color-mint-500 {
+  --rdb-color: var(--rdb-color-mint-500);
+  --rdb-contrast-color: var(--rdb-contrast-color-mint-500);
+}
+
+.rdb-color-mint-700 {
+  --rdb-color: var(--rdb-color-mint-700);
+  --rdb-contrast-color: var(--rdb-contrast-color-mint-700);
+}
+
+.rdb-color-mint-900 {
+  --rdb-color: var(--rdb-color-mint-900);
+  --rdb-contrast-color: var(--rdb-contrast-color-mint-900);
+}
+
+.rdb-enumeration-color-label {
+  float: none;
+  margin: 0;
+  display: block;
+  text-align: inherit;
+  background-color: var(--rdb-color);
+  color: var(--rdb-contrast-color);
+  border-radius: 3px;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 15%);
+}
+
+.rdb-enumeration-color-palettes {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(125px, 1fr));
+  gap: 0.5em;
+
+  ol {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25em;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,9 @@ en:
   permission_view_dashboards: View Dashboards
   permission_configure_dashboards: Configure Dashboards
   menu_label_dashboard: Dashboard
+  rdb:
+    enumeration:
+      dashboard_color: "Dashboard: Color"
   rdb_taskboard: Task Board
   rdb_planningboard: Planning Board
   rdb_filter_version_all: All Versions

--- a/db/migrate/20260617000000_add_color_to_enumerations.rb
+++ b/db/migrate/20260617000000_add_color_to_enumerations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddColorToEnumerations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :enumerations, :dashboard_color, :string, null: true
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/BlockLength
+
 # -------------------------------------------------------------------
 #   Users
 # -------------------------------------------------------------------
@@ -185,3 +187,146 @@ Role.where(name: 'Reporter').first!.tap do |role|
   role.permissions << :view_dashboards
   role.save!
 end
+
+# -------------------------------------------------------------------
+#   Memberships and project setup
+# -------------------------------------------------------------------
+
+seed_users = [john, jane, alice, bob, carol, dave, eve, mallory, oscar]
+seed_projects = [smithcorp, engineering, finance, management]
+
+manager_role = Role.find_by(name: 'Manager')
+developer_role = Role.find_by(name: 'Developer')
+reporter_role = Role.find_by(name: 'Reporter')
+
+seed_projects.each do |project|
+  # Make sure all available trackers are enabled for broad demo coverage.
+  missing_trackers = Tracker.sorted.to_a - project.trackers.to_a
+  project.trackers << missing_trackers if missing_trackers.any?
+
+  seed_users.each do |user|
+    member = Member.find_or_initialize_by(project: project, user: user)
+    member_roles = member.roles.to_a
+
+    if user == john && manager_role
+      member_roles << manager_role
+    elsif user == jane && reporter_role
+      member_roles << reporter_role
+    elsif developer_role
+      member_roles << developer_role
+    end
+
+    member.roles = member_roles.uniq
+    member.save!
+  end
+end
+
+# -------------------------------------------------------------------
+#   Categories ("components") and versions
+# -------------------------------------------------------------------
+
+project_components = {
+  'smithcorp' => %w[Operations Infrastructure Security Compliance],
+  'engineering' => %w[Backend Frontend Data QA],
+  'finance' => %w[Accounting Billing Forecasting Auditing],
+  'management' => %w[Planning Roadmap People Process]
+}.freeze
+
+version_data = [
+  {name: '1.0', months: -2, status: 'closed'},
+  {name: '1.1', months: 1, status: 'open'},
+  {name: '2.0', months: 3, status: 'open'}
+].freeze
+
+seed_projects.each do |project|
+  component_names = project_components.fetch(project.identifier, ['General'])
+  component_names.each do |name|
+    IssueCategory.find_or_create_by!(project: project, name: name)
+  end
+
+  version_data.each do |version_data|
+    Version.find_or_initialize_by(project: project, name: version_data[:name]).tap do |version|
+      version.status = version_data[:status]
+      version.effective_date = Date.current >> version_data[:months]
+      version.description = "Seeded demo version #{version_data[:name]} for #{project.name}"
+      version.save!
+    end
+  end
+end
+
+# Set deterministic sample colors for priorities in dashboard cards.
+priority_palette = %w[gray-300 green-400 yellow-300 orange-400 red-400 blue-400]
+IssuePriority.sorted.each_with_index do |priority, index|
+  color = priority_palette[index % priority_palette.length]
+  priority.update!(dashboard_color: color)
+end
+
+# -------------------------------------------------------------------
+#   Issues for dashboard demo data
+# -------------------------------------------------------------------
+
+trackers = Tracker.sorted.to_a
+statuses = IssueStatus.sorted.to_a
+priorities = IssuePriority.sorted.to_a
+reference_date = Date.current
+
+seed_projects.each do |project|
+  categories = project.issue_categories.order(:name).to_a
+  # Redmine validates fixed_version against issue.assignable_versions,
+  # which uses project.shared_versions.open.
+  versions = project.shared_versions.open.sorted.to_a
+
+  seed_users.each_with_index do |author, author_index|
+    priorities.each_with_index do |priority, priority_index|
+      issue_number = (author_index * priorities.size) + priority_index + 1
+      status = statuses[(author_index + priority_index) % statuses.size]
+      assignee = if issue_number % 5 == 0
+                   nil
+                 else
+                   seed_users[(author_index + priority_index + 1) % seed_users.size]
+                 end
+      category = (issue_number % 4).zero? ? nil : categories[(issue_number - 1) % categories.size]
+      version = if versions.any? && (issue_number % 3) != 0
+                  versions[(issue_number - 1) % versions.size]
+                end
+      tracker = trackers[(issue_number - 1) % trackers.size]
+      start_date = reference_date - ((issue_number % 30) + 1)
+      due_date = start_date + ((issue_number % 12) + 3)
+
+      subject = "[Seed][#{project.identifier}] #{author.login.capitalize} #{priority.name} #{issue_number}"
+
+      Issue.find_or_initialize_by(project: project, subject: subject).tap do |issue|
+        issue.author = author
+        issue.assigned_to = assignee
+        issue.priority = priority
+        issue.tracker = tracker
+        issue.status = status
+        issue.category = category
+        issue.fixed_version = version
+        issue.start_date = start_date
+        issue.due_date = due_date
+        issue.estimated_hours = ((issue_number % 8) + 1) * 2
+        issue.done_ratio = if status.is_closed?
+                             100
+                           elsif status.position <= 2
+                             (issue_number % 4) * 10
+                           else
+                             40 + ((issue_number % 6) * 10)
+                           end
+        issue.description = [
+          "Seeded dashboard demo issue for #{project.name}.",
+          "Author: #{author.name}",
+          "Assignee: #{assignee&.name || 'Unassigned'}",
+          "Priority: #{priority.name}",
+          "Tracker: #{tracker.name}",
+          "Component: #{category&.name || 'Unassigned'}",
+          "Version: #{version&.name || 'Unassigned'}"
+        ].join("\n")
+
+        issue.save!
+      end
+    end
+  end
+end
+
+# rubocop:enable Metrics/BlockLength

--- a/init.rb
+++ b/init.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
-require 'redmine'
+$LOAD_PATH.unshift "#{__dir__}/lib"
+
+# Explicitly register the plugin's hooks and patches again since they
+# are lost in development environment when code is reloaded.
+#
+# The classes are automatically resolved by Zeitwerk, but stored
+# references get lost on reloaded. Since Redmine does reload the
+# `init.rb` then too, we can just re-register the hooks and patches
+# here.
+RedmineDashboard::Hooks.register!
+RedmineDashboard::Patch.apply!
 
 Redmine::Plugin.register :redmine_dashboard do
   name 'Redmine Dashboard plugin'
@@ -19,6 +29,7 @@ Redmine::Plugin.register :redmine_dashboard do
     }
     permission :configure_dashboards, {rdb_dashboard: [:configure]}
   end
+
   menu :project_menu, :dashboard, {controller: 'rdb_dashboard', action: 'index'},
     caption: :menu_label_dashboard, after: :new_issue
 end

--- a/lib/redmine_dashboard/color.rb
+++ b/lib/redmine_dashboard/color.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module RedmineDashboard
+  module Color
+    PALETTE = {
+      gray: %w[gray-100 gray-300 gray-500 gray-700 gray-900],
+      red: %w[red-100 red-300 red-500 red-700 red-900],
+      orange: %w[orange-100 orange-300 orange-500 orange-700 orange-900],
+      amber: %w[amber-100 amber-300 amber-500 amber-700 amber-900],
+      yellow: %w[yellow-100 yellow-300 yellow-500 yellow-700 yellow-900],
+      lime: %w[lime-100 lime-300 lime-500 lime-700 lime-900],
+      green: %w[green-100 green-300 green-500 green-700 green-900],
+      mint: %w[mint-100 mint-300 mint-500 mint-700 mint-900],
+      cyan: %w[cyan-100 cyan-300 cyan-500 cyan-700 cyan-900],
+      blue: %w[blue-100 blue-300 blue-500 blue-700 blue-900],
+      indigo: %w[indigo-100 indigo-300 indigo-500 indigo-700 indigo-900],
+      purple: %w[purple-100 purple-300 purple-500 purple-700 purple-900],
+      pink: %w[pink-100 pink-300 pink-500 pink-700 pink-900]
+    }.freeze
+
+    ALL = PALETTE.values.flatten.freeze
+  end
+end

--- a/lib/redmine_dashboard/hooks.rb
+++ b/lib/redmine_dashboard/hooks.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module RedmineDashboard
+  class Hooks < Redmine::Hook::ViewListener
+    def self.register!
+      # Avoid registering the hook multiple times in development mode
+      # when code is reloaded or loaded the first time, and the previous
+      # registration is not lost (usually it is).
+      unless Redmine::Hook.listeners.any?(self)
+        Redmine::Hook.add_listener(self)
+      end
+    end
+
+    def view_layouts_base_html_head(_context)
+      stylesheet_link_tag 'global.css', plugin: :redmine_dashboard
+    end
+  end
+end

--- a/lib/redmine_dashboard/patch.rb
+++ b/lib/redmine_dashboard/patch.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module RedmineDashboard
+  module Patch
+    def self.apply!
+      ::IssuePriority.include(EnumerationColor)
+      ::EnumerationsController.prepend(EnumerationsControllerColor)
+    end
+  end
+end

--- a/lib/redmine_dashboard/patch/enumeration_color.rb
+++ b/lib/redmine_dashboard/patch/enumeration_color.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module RedmineDashboard
+  module Patch
+    module EnumerationColor
+      extend ActiveSupport::Concern
+
+      included do
+        validates :dashboard_color, inclusion: {in: Color::ALL}, allow_blank: true
+      end
+
+      def dashboard_color_css_class
+        if dashboard_color.present?
+          "rdb-color-#{dashboard_color}"
+        else
+          'rdb-color-gray-300'
+        end
+      end
+    end
+  end
+end

--- a/lib/redmine_dashboard/patch/enumerations_controller_color.rb
+++ b/lib/redmine_dashboard/patch/enumerations_controller_color.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module RedmineDashboard
+  module Patch
+    module EnumerationsControllerColor
+      extend ActiveSupport::Concern
+
+      def enumeration_params
+        dashboard_color = params.dig(:enumeration, :dashboard_color)
+        if dashboard_color.present?
+          super.merge(dashboard_color: dashboard_color)
+        else
+          super
+        end
+      end
+    end
+  end
+end

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint:format": "prettier --check .",
     "lint:css": "stylelint --allow-empty-input 'assets/**/*.css'",
     "lint:erb": "bundle exec herb lint app/views",
+    "lint:ec": "editorconfig-checker .",
     "postinstall": "husky"
   },
   "lint-staged": {

--- a/spec/features/admin/issue_priority_color_spec.rb
+++ b/spec/features/admin/issue_priority_color_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Admin: Issue Priority Color', js: true do
+  fixtures %i[
+    enumerations
+    users
+  ]
+
+  let(:priority) { IssuePriority.find_by!(name: 'Normal') }
+
+  before do
+    login_as_admin
+  end
+
+  it 'allows selecting and saving a color' do
+    visit "/enumerations/#{priority.id}/edit"
+
+    within_fieldset('Dashboard: Color') do
+      expect(page).to have_field('red-100')
+      expect(page).to have_field('blue-300')
+      expect(page).to have_field('green-500')
+      expect(page).to have_field('yellow-700')
+
+      choose 'gray-500'
+    end
+
+    click_on 'Save'
+    click_on 'Normal'
+
+    expect(page).to have_field('enumeration[dashboard_color]', with: 'gray-500', checked: true)
+    expect(priority.reload.dashboard_color).to eq('gray-500')
+  end
+
+  context 'for non-priority enumerations' do
+    let(:activity) { TimeEntryActivity.find_by(name: 'Design') }
+
+    it 'does not show the color picker' do
+      visit "/enumerations/#{activity.id}/edit"
+      expect(page).not_to have_selector('fieldset')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,9 @@ end
 # is feasible and useful.
 Rails.application.eager_load! if ENV['CI'].present?
 
+ActiveRecord::Migrator.migrations_paths << File.expand_path('../db/migrate', __dir__)
+ActiveRecord::Migration.maintain_test_schema!
+
 require 'rspec/rails'
 require 'database_cleaner/active_record'
 


### PR DESCRIPTION
This PR adds two improvements for accessibility and UX:

### Color customization for issue priority indicator

An administrator can choose a color from a palette for 65 color shades, for example, to change colors due to a different issue priority order or the preferences of the team members.

I've implemented a color palatte approach, vs. a free color input, so that the theme can define the colors and shades, and adjust them to the needs of the theme, for example, a dark theme, high contrast, or to better match the overall theme coloring.

The palette is implemented using CSS variables using visually distinctive oklch-based color and shade schemes. The text and background colors have been checked for WCAG color contrast compliance.

### Distinct overdue shape

OVerdue tickets are no longer marked by color only, but have a distinct outline shape now too. This eases identifying overdue issues independently of the color.


### Examples

<img width="1280" height="1014" alt="image" src="https://github.com/user-attachments/assets/12f6a1ff-5771-4bd0-8e92-8592d10d04a7" />
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/09408446-d1c8-4bab-904c-668c260f17a3" />

---

Note: This is first feature that heavily patches into Redmine's core and requires a database migration. It might interfere with other plugins patching enumerations too, since ther is no hook to extend that view (yet).

When upgrading, remember to migrate the database:

```
bundle exec rake redmine:plugins:migrate RAILS_ENV=production
```

Closes #802