### PR TITLE
chore: Simplify and modernize helpers

### DIFF
--- a/app/helpers/rdb_dashboard_helper.rb
+++ b/app/helpers/rdb_dashboard_helper.rb
@@ -1,106 +1,110 @@
 # frozen_string_literal: true
 
 module RdbDashboardHelper
-  def render_rdb_menu(id, title, options = {}, &container)
-    options[:class] ||= ''
-    options[:class] += ' rdb-menu-right' if options[:right]
-    options[:class] += ' rdb-small' if options[:small]
+  def rdb_menu(id, title, header: nil, **options, &container)
+    menu_classes = class_names(
+      options[:class],
+      'rdb-menu',
+      "rdb-menu-#{id}",
+      'rdb-menu-right': options[:right],
+      'rdb-small': options[:small],
+    )
 
-    slim_tag :div, class: "rdb-menu rdb-menu-#{id} #{options[:class]}" do
-      if options[:anchor]
-        link = options[:anchor].call.to_s.html_safe
-      else
-        link = link_to(title, '#', class: 'rdb-menu-link')
-      end
+    link = link_to(title, '#', class: 'rdb-menu-link')
 
-      if options[:header] && %i[h1 h2 h3 h4 h5].include?(options[:header].to_sym)
-        slim_tag(options[:header], link)
-      else
-        concat link
-      end
+    if %i[h1 h2 h3 h4 h5].include?(header)
+      link = content_tag(header, link)
+    end
 
-      slim_tag :div, class: "rdb-container #{'rdb-container-right' if options[:right]}" do
-        slim_tag :div, class: "rdb-container-wrapper #{'rdb-icons' if options[:icons]}" do
-          if options[:inlet]
-            slim_tag(:div, class: 'rdb-container-inlet', &container)
+    tag.div(class: menu_classes) do
+      concat link
+      concat(
+        tag.div(
+          class: class_names('rdb-container', 'rdb-container-right': options[:right]),
+        ) do
+          tag.div(
+            class: class_names('rdb-container-wrapper', 'rdb-icons': options[:icons]),
+          ) do
+            if options[:inlet]
+              tag.div(class: 'rdb-container-inlet', &container)
+            else
+              yield
+            end
+          end
+        end,
+      )
+    end
+  end
+
+  def rdb_menu_list( # rubocop:disable Metrics/ParameterLists
+    items = nil,
+    async: false,
+    title: nil,
+    list_tag: :ul,
+    list_class: nil,
+    **kwargs
+  )
+    list_classes = class_names(kwargs[:class], 'rdb-list', 'rdb-async': async)
+    tag.div(class: list_classes) do
+      concat tag.h3(title) if title.present?
+
+      concat(
+        content_tag(list_tag, class: list_class) do
+          if items
+            items.each do |item|
+              concat(tag.li { yield item })
+            end
           else
             yield
           end
-        end
-      end
+        end,
+      )
     end
   end
 
-  def render_rdb_menu_list(items = nil, options = {})
-    if items.is_a?(Hash)
-      options = items
-      items = nil
-    end
-
-    slim_tag :div, class: "rdb-list #{'rdb-async' if options[:async]} #{options[:class]}" do
-      slim_tag :h3, options[:title] if options[:title]
-      slim_tag options[:list_tag] || :ul, class: options[:list_class] do
-        if items
-          items.each do |item|
-            slim_tag :li do
-              yield item
-            end
-          end
-        else
-          yield
-        end
-      end
-    end
+  def rdb_menu_list_item(classes: nil, async: nil, &block)
+    tag.li(
+      class: class_names(classes, 'rdb-async': async),
+      &block
+    )
   end
 
-  def render_rdb_menu_list_item(options = {}, &block)
-    slim_tag(:li, class: options[:async] ? 'rdb-async' : '', &block)
+  def rdb_checkbox_link_to(*args, enabled: nil, show_disabled: nil, **kwargs)
+    kwargs[:class] = class_names(
+      kwargs[:class],
+      'rdb-checkbox-link',
+      'rdb-checkbox-link-enabled': enabled,
+      'rdb-checkbox-link-disabled': !enabled && show_disabled,
+    )
+
+    link_to(*args, **kwargs)
   end
 
-  def rdb_checkbox_link_to(*args)
-    options = args.extract_options!
-    options[:class] ||= ''
-    options[:class] += ' rdb-checkbox-link'
-    options[:class] += ' rdb-checkbox-link-enabled' if options[:enabled]
-    options[:class] += ' rdb-checkbox-link-disabled' if !options[:enabled] && options[:show_disabled]
-    options[:class].strip!
-
-    options.delete :enabled
-    options.delete :show_disabled
-
-    args << options
-
-    link_to(*args)
-  end
-
-  def rdb_update_path(issue, options = {})
-    send(:"rdb_#{@board.id}_update_path", {
+  # rubocop:disable Rails/HelperInstanceVariable
+  def rdb_update_path(issue, **kwargs)
+    send(
+      :"rdb_#{@board.id}_update_path",
       issue: issue.id,
-      lock_version: issue.lock_version
-    }.merge(options),)
+      lock_version: issue.lock_version,
+      **kwargs,
+    )
   end
 
-  def rdb_move_path(issue, options = {})
-    send(:"rdb_#{@board.id}_move_path", {
+  def rdb_move_path(issue, **kwargs)
+    send(
+      :"rdb_#{@board.id}_move_path",
       issue: issue.id,
-      lock_version: issue.lock_version
-    }.merge(options),)
+      lock_version: issue.lock_version,
+      **kwargs,
+    )
   end
 
-  def rdb_filter_path(options = {})
-    send(:"rdb_#{@board.id}_filter_path", options)
+  def rdb_filter_path(**kwargs)
+    send(:"rdb_#{@board.id}_filter_path", **kwargs)
   end
 
-  def rdb_board_path(options = {})
-    send(:"rdb_#{@board.id}_path", options)
+  def rdb_board_path(**kwargs)
+    send(:"rdb_#{@board.id}_path", **kwargs)
   end
-
-  private
-
-  def slim_tag(name, content = nil, **attrs)
-    concat tag(name, attrs, true, true)
-    concat(content) if content.present?
-    yield if block_given?
-    concat "</#{name}>".html_safe
-  end
+  # rubocop:enable Rails/HelperInstanceVariable
 end

--- a/app/views/rdb_dashboard/issues/_card.html.slim
+++ b/app/views/rdb_dashboard/issues/_card.html.slim
@@ -1,4 +1,3 @@
-/ ISSUE CARD
 .rdb-card
   div class="rdb-priority rdb-priority-#{issue.priority.position}"
     header.rdb-card-header
@@ -12,4 +11,3 @@
     .rdb-card-content
       .rdb-card-subject.rdb-property-subject = issue.subject
       = render partial: 'rdb_dashboard/issues/issue_properties', locals: {issue: issue}
-/ ISSUE CARD END

--- a/app/views/rdb_dashboard/issues/_compact.html.slim
+++ b/app/views/rdb_dashboard/issues/_compact.html.slim
@@ -1,4 +1,3 @@
-/ ISSUE COMPACT
 .rdb-compact
   .rdb-priority class="rdb-priority-#{issue.priority.position}"
 
@@ -12,4 +11,3 @@
 
     .rdb-compact-content
       .rdb-compact-subject.rdb-property-subject = issue.subject
-/ ISSUE COMPACT END

--- a/app/views/rdb_dashboard/issues/_issue_menu.html.slim
+++ b/app/views/rdb_dashboard/issues/_issue_menu.html.slim
@@ -1,19 +1,19 @@
-- render_rdb_menu :issue, @board.issue_id(issue), small: true do
-  - render_rdb_menu_list title: t(:rdb_issue_menu_redmine_issue) do
-    - render_rdb_menu_list_item do
+= rdb_menu :issue, @board.issue_id(issue), small: true do
+  = rdb_menu_list title: t(:rdb_issue_menu_redmine_issue) do
+    = rdb_menu_list_item do
       = link_to t(:rdb_issue_menu_show), issue_path(issue)
     - if @board.editable?
-      - render_rdb_menu_list_item do
+      = rdb_menu_list_item do
         = link_to t(:rdb_issue_menu_edit), edit_issue_path(issue)
       - if issue.assigned_to_id == User.current.id
-        - render_rdb_menu_list_item async: true do
+        = rdb_menu_list_item async: true do
           = link_to t(:rdb_issue_menu_unassign_me), rdb_update_path(issue, unassign_me: true)
       - else
-        - render_rdb_menu_list_item async: true do
+        = rdb_menu_list_item async: true do
           = link_to t(:rdb_issue_menu_assign_me), rdb_update_path(issue, assign_me: true)
 
   - if @board.editable? && (issue.assigned_to_id == User.current.id || User.current.admin?)
-    - render_rdb_menu_list title: t(:rdb_issue_menu_progress_title), async: true, list_tag: :div do
+    = rdb_menu_list title: t(:rdb_issue_menu_progress_title), async: true, list_tag: :div do
       ul.rdb-issue-menu-progress
         - [0, 20, 40].each do |value|
           li = link_to t(:rdb_issue_menu_progress, count: value), rdb_update_path(issue, done_ratio: value)

--- a/app/views/rdb_dashboard/taskboard/_header.html.slim
+++ b/app/views/rdb_dashboard/taskboard/_header.html.slim
@@ -1,69 +1,69 @@
 .rdb-board
   = link_to '', rdb_board_path, class: 'rdb-async', id: 'rdb-refresh'
 
-  - render_rdb_menu :board, @board.name, header: :h2 do
-    - render_rdb_menu_list [:taskboard] do |val|
+  = rdb_menu :board, @board.name, header: :h2 do
+    = rdb_menu_list [:taskboard] do |val|
       = link_to t("rdb_#{val}"), rdb_path(board: val)
 
 - if @board.versions.any?
   .rdb-filter.rdb-async
-    - render_rdb_menu :versions, @board.filters[:version].title do
-      - render_rdb_menu_list [:all, :unassigned] do |val|
+    = rdb_menu :versions, @board.filters[:version].title do
+      = rdb_menu_list [:all, :unassigned] do |val|
         = link_to t("rdb_filter_version_#{val}"), rdb_filter_path(version: val)
-      - render_rdb_menu_list @board.filters[:version].versions do |val|
+      = rdb_menu_list @board.filters[:version].versions do |val|
         = link_to val.name, rdb_filter_path(version: val.id)
 
 .rdb-filter.rdb-async
-  - render_rdb_menu :tracker, @board.filters[:tracker].title, icons: true do
-    - render_rdb_menu_list [:all] do |val|
+  = rdb_menu :tracker, @board.filters[:tracker].title, icons: true do
+    = rdb_menu_list [:all] do |val|
       = link_to t("rdb_filter_tracker_#{val}"), rdb_filter_path(tracker: val)
-    - render_rdb_menu_list @board.trackers do |val|
+    = rdb_menu_list @board.trackers do |val|
       span.rdb-multicheck
         = rdb_checkbox_link_to '', rdb_filter_path(tracker: val.id), enabled: @board.filters[:tracker].enabled?(val.id), show_disabled: true
         = link_to val.name, rdb_filter_path(tracker: val.id, only: true)
 
 - if @board.issue_categories.any?
   .rdb-filter.rdb-async
-    - render_rdb_menu :categories, @board.filters[:category].title, icons: true do
-      - render_rdb_menu_list [:all] do |val|
+    = rdb_menu :categories, @board.filters[:category].title, icons: true do
+      = rdb_menu_list [:all] do |val|
         = link_to t("rdb_filter_category_#{val}"), rdb_filter_path(category: val)
-      - render_rdb_menu_list @board.issue_categories do |val|
+      = rdb_menu_list @board.issue_categories do |val|
         span.rdb-multicheck
           = rdb_checkbox_link_to '', rdb_filter_path(category: val.id), enabled: @board.filters[:category].enabled?(val.id), show_disabled: true
           = link_to val.name, rdb_filter_path(category: val.id, only: true)
 
 .rdb-filter.rdb-async
-  - render_rdb_menu :assignee, @board.filters[:assignee].title do
-    - render_rdb_menu_list [:all, :me, :none] do |val|
+  = rdb_menu :assignee, @board.filters[:assignee].title do
+    = rdb_menu_list [:all, :me, :none] do |val|
       = link_to t("rdb_filter_assignee_#{val}"), rdb_filter_path(assignee: val)
-    - render_rdb_menu_list @board.assignees do |val|
+    = rdb_menu_list @board.assignees do |val|
       - if User === val
         = link_to val.name, rdb_filter_path(assignee: val.id)
-    - render_rdb_menu_list @board.assignees do |val|
+    = rdb_menu_list @board.assignees do |val|
       - if Group === val
         = link_to val.name, rdb_filter_path(assignee: val.id)
 
 .rdb-option.rdb-async
-  - render_rdb_menu :options, t(:rdb_options), right: true, icons: true do
-    - render_rdb_menu_list do
-      - render_rdb_menu_list_item do
+  = rdb_menu :options, t(:rdb_options), right: true, icons: true do
+    = rdb_menu_list do
+      = rdb_menu_list_item do
         = rdb_checkbox_link_to t(:rdb_options_change_assignee), rdb_board_path(change_assignee: !@board.options[:change_assignee]),
             enabled: @board.options[:change_assignee], title: t(:rdb_options_change_assignee_info)
         = rdb_checkbox_link_to t(:rdb_options_hide_done), rdb_board_path(hide_done: !@board.options[:hide_done]),
             enabled: @board.options[:hide_done], title: t(:rdb_options_hide_done_info)
         = rdb_checkbox_link_to t(:rdb_options_include_subprojects), rdb_board_path(include_subprojects: (@board.project_ids.size > 1) ? 'false' : 'true'),
             enabled: (@board.project_ids.size > 1)
-    - render_rdb_menu_list @board.column_list, title: t(:rdb_options_columns) do |column|
+    = rdb_menu_list @board.column_list, title: t(:rdb_options_columns) do |column|
       = rdb_checkbox_link_to column.title, rdb_board_path(hide_column: column.id), enabled: @board.columns[column.id].visible?
-    - render_rdb_menu_list do
-      - render_rdb_menu_list_item do
+    = rdb_menu_list do
+      = rdb_menu_list_item do
         = link_to t(:rdb_options_fullscreen), 'javascript:Rdb.rdbToggleFullscreen();', id: "rdb-option-fullscreen"
-      - render_rdb_menu_list_item do
+      = rdb_menu_list_item do
         = link_to t(:rdb_options_reset), rdb_filter_path(reset: 1), id: "rdb-reset", title: t(:rdb_options_reset_info)
 
 .rdb-option.rdb-async
-  - render_rdb_menu :view, t(:rdb_options_view), right: true do
-    - render_rdb_menu_list RdbDashboard::VIEW_MODES, title: t(:rdb_options_issue_view) do |view|
+  = rdb_menu :view, t(:rdb_options_view), right: true do
+    = rdb_menu_list RdbDashboard::VIEW_MODES, title: t(:rdb_options_issue_view) do |view|
       = rdb_checkbox_link_to t(:"rdb_options_issue_view_#{view}"), rdb_board_path(view: view), enabled: @board.options[:view] == view
-    - render_rdb_menu_list [:none, :tracker, :category, :priority, :assignee, :version, :parent, :project], title: t(:rdb_options_group) do |group|
+    = rdb_menu_list [:none, :tracker, :category, :priority, :assignee, :version, :parent, :project], title: t(:rdb_options_group) do |group|
       = rdb_checkbox_link_to t(:"rdb_group_#{group}"), rdb_board_path(group: group), enabled: @board.options[:group] == group

--- a/spec/support/rdb_request_helpers.rb
+++ b/spec/support/rdb_request_helpers.rb
@@ -14,23 +14,11 @@ module RdbRequestHelpers
   end
 
   def login_as(user, password)
-    # Ensure a current page is loaded. Otherwise, visit might be
-    # swallowed by the current page load.
-    page.find('html')
+    visit '/'
+
+    Capybara.reset_sessions!
 
     visit '/login'
-
-    # Wait for current page to have been loaded
-    page.find('html')
-
-    if current_path != '/login'
-      # Redmine 7 has "Sign out" hidden in a dropdown menu under the
-      # user avatar. Therefore, click the "invisible" link there too:
-      click_link 'Sign out', visible: :all
-      click_link 'Sign in'
-    end
-
-    expect(page).to have_content('Login')
 
     fill_in 'username', with: user
     fill_in 'password', with: password


### PR DESCRIPTION
Replace hash-building with keyword arguments and modern Ruby syntax.
This improves readability and maintainability of the code.

Remove the custom `slim_tag` method and replace it with Rails' built-in
`content_tag` and `tag` helpers, which are more idiomatic and easier to
understand.